### PR TITLE
Add API env config and simple backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,2 @@
+MONGO_URI=mongodb+srv://example:example@cluster.mongodb.net/db
+JWT_SECRET=meteo_secret

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,50 @@
+/* eslint-env node */
+/* eslint-disable no-undef */
+import express from 'express';
+import cors from 'cors';
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const { JWT_SECRET, MONGO_URI } = process.env;
+console.log('Mongo URI:', MONGO_URI);
+
+app.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password required' });
+  }
+  // This is a mock authentication for example purposes
+  const token = jwt.sign({ email }, JWT_SECRET || 'secret');
+  res.json({ token });
+});
+
+app.get('/weather/:city', (req, res) => {
+  const { city } = req.params;
+  const data = {
+    id: city,
+    location_name: city.charAt(0).toUpperCase() + city.slice(1),
+    latitude: 0,
+    longitude: 0,
+    datetime: new Date().toISOString(),
+    temperature: 25,
+    humidity: 50,
+    weather_description: 'Açık',
+    wind_speed: 3,
+    wind_direction: 90,
+    pressure: 1010,
+    icon_code: '01d',
+    expertOpinions: [],
+  };
+  res.json(data);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "meteo-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import SearchBar from './components/searchbar';
 import WeatherCard from './components/WeatherCard';
 import './App.css';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 function App() {
   const [user, setUser] = useState(null);
   const [weatherList, setWeatherList] = useState([]);
@@ -24,79 +26,27 @@ function App() {
     document.body.style.padding = "0";
   }, [weatherList, currentIndex]);
 
-  const handleSearch = (cityId) => {
-    const mockDatabase = {
-      ankara: {
-        id: "ankara",
-        location_name: "Ankara",
-        latitude: 39.9288,
-        longitude: 32.8541,
-        datetime: new Date().toISOString(),
-        temperature: 24.5,
-        humidity: 60,
-        weather_description: "Açık",
-        wind_speed: 5.4,
-        wind_direction: 270,
-        pressure: 1013,
-        icon_code: "01d",
-        expertOpinions: [
-          "Önümüzdeki hafta sıcaklıklar mevsim normallerinde olacak.",
-          "Rüzgar güneybatı yönünden esecek, tarım faaliyetleri için uygun." 
-        ],
-      },
-      istanbul: {
-        id: "istanbul",
-        location_name: "İstanbul",
-        latitude: 41.0082,
-        longitude: 28.9784,
-        datetime: new Date().toISOString(),
-        temperature: 20.1,
-        humidity: 68,
-        weather_description: "Bulutlu",
-        wind_speed: 4.3,
-        wind_direction: 120,
-        pressure: 1012,
-        icon_code: "03d",
-        expertOpinions: [
-          "Nem oranı yüksek, kronik rahatsızlığı olanlar dikkatli olmalı.",
-          "Yağış ihtimali düşük, hava çoğunlukla bulutlu seyredecek." 
-        ],
-      },
-      izmir: {
-        id: "izmir",
-        location_name: "İzmir",
-        latitude: 38.4192,
-        longitude: 27.1287,
-        datetime: new Date().toISOString(),
-        temperature: 27.4,
-        humidity: 55,
-        weather_description: "Parçalı Bulutlu",
-        wind_speed: 3.9,
-        wind_direction: 90,
-        pressure: 1009,
-        icon_code: "02d",
-        expertOpinions: [
-          "Parçalı bulutlu hava deniz ulaşımını etkilemeyecek.",
-          "Hafta sonu sıcaklıklar birkaç derece artacak." 
-        ],
-      }
-    };
+  const handleSearch = async (cityId) => {
+    if (!cityId) return;
 
-    const alreadyExists = weatherList.some(item => item.id === cityId);
-    if (alreadyExists) {
-      alert("Bu şehir zaten eklendi.");
-      return;
-    }
-    if(!cityId)return;
-    const mockData = mockDatabase[cityId];
-    if (mockData) {
-      setWeatherList(prev => {
-        const updated = [...prev, mockData];
-        setCurrentIndex(updated.length - 1); // kritik düzeltme
+    try {
+      const res = await fetch(`${API_URL}/weather/${cityId}`);
+      if (!res.ok) throw new Error('not found');
+      const data = await res.json();
+
+      const alreadyExists = weatherList.some((item) => item.id === data.id);
+      if (alreadyExists) {
+        alert('Bu şehir zaten eklendi.');
+        return;
+      }
+
+      setWeatherList((prev) => {
+        const updated = [...prev, data];
+        setCurrentIndex(updated.length - 1);
         return updated;
       });
-    } else {
-      alert("Bu şehir için test verisi yok.");
+    } catch {
+      alert('Şehir bulunamadı');
     }
   };
 
@@ -115,6 +65,7 @@ function App() {
     setWeatherList([]);
     setCurrentIndex(0);
     document.body.style.backgroundImage = "none";
+    localStorage.removeItem('token');
   };
 
   return (

--- a/src/components/AuthPage.jsx
+++ b/src/components/AuthPage.jsx
@@ -1,16 +1,30 @@
 import { useState } from 'react';
 import './auth.css';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 function AuthPage( { onLogin }){
     const [isLogin, setIsLogin] = useState(true);
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
 
-    const handleSubmit = (e) => {
+    const handleSubmit = async (e) => {
         e.preventDefault();
 
-        if(email && password) {
-            onLogin ({ email });
+        if (email && password) {
+            try {
+                const res = await fetch(`${API_URL}/login`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email, password })
+                });
+                if (!res.ok) throw new Error('Login failed');
+                const data = await res.json();
+                localStorage.setItem('token', data.token);
+                onLogin({ email });
+            } catch {
+                alert('Giriş başarısız');
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- add frontend `.env` for API URL
- add backend express server using env variables
- store JWT token in `localStorage` and use env variable for API calls

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685568cedc0c83299cf58a9935603a55