### PR TITLE
Enable API-based comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Meteosphere, React ve Vite kullanılarak geliştirilmiş basit bir hava durumu u
 - Ankara, İstanbul ve İzmir için mock hava durumu verileri
 - Şehir arama ve sonuçları arasında gezinme
 - Giriş yapmış kullanıcılar için yorum ekleme
+- Yorumlar `/api/comments/:city` adresinden yüklenir
+- Yeni yorumlar JWT ile `/api/comments` adresine gönderilir
 
 ## Kurulum
 

--- a/src/components/AuthPage.jsx
+++ b/src/components/AuthPage.jsx
@@ -6,11 +6,24 @@ function AuthPage( { onLogin }){
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
 
-    const handleSubmit = (e) => {
+    const handleSubmit = async (e) => {
         e.preventDefault();
 
-        if(email && password) {
-            onLogin ({ email });
+        if (!email || !password) return;
+
+        try {
+            const res = await fetch('/api/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, password })
+            });
+
+            if (!res.ok) throw new Error('login failed');
+
+            const data = await res.json();
+            onLogin({ email, token: data.token });
+        } catch {
+            alert('Giris basarisiz');
         }
     };
 


### PR DESCRIPTION
## Summary
- add comment API instructions to README
- fetch JWT token on login and send with comments
- load existing comments per city from API
- submit new comments through the API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685568ab53a08329b553edd75d83a0f9