### PR TITLE
Add basic Express authentication server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,17 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "express": "^4.18.2",
+    "mongoose": "^7.6.3",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+/* eslint-env node */
+/* global process */
+import express from 'express';
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import authRoute from './server/routes/auth.js';
+
+dotenv.config();
+
+const app = express();
+
+app.use(express.json());
+app.use('/api/auth', authRoute);
+
+const PORT = process.env.PORT || 5000;
+
+mongoose
+  .connect(process.env.MONGO_URL, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  })
+  .then(() => {
+    app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  })
+  .catch((err) => console.error(err));

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,13 @@
+/* eslint-env node */
+import mongoose from 'mongoose';
+
+const UserSchema = new mongoose.Schema(
+  {
+    username: { type: String, required: true, unique: true },
+    email: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('User', UserSchema);

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,40 @@
+/* eslint-env node */
+/* global process */
+import express from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  try {
+    const salt = await bcrypt.genSalt(10);
+    const hashedPassword = await bcrypt.hash(req.body.password, salt);
+    const newUser = new User({
+      username: req.body.username,
+      email: req.body.email,
+      password: hashedPassword,
+    });
+    await newUser.save();
+    res.status(201).json({ message: 'User created' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const user = await User.findOne({ email: req.body.email });
+    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+    const validPassword = await bcrypt.compare(req.body.password, user.password);
+    if (!validPassword)
+      return res.status(401).json({ message: 'Invalid credentials' });
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add a Mongoose `User` model
- create authentication endpoints (`/register` and `/login`)
- wire new router into an Express server
- update dependencies to include backend libraries

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685568966c6c8329a966bb45a6f7ce7a