### PR TITLE
Implement JWT login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,6 @@ const API_URL = import.meta.env.VITE_API_URL;
 function App() {
 
   const [user, setUser] = useState(null);
-  const [username, setUsername] = useState('');
   const [weatherList, setWeatherList] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [showLogin, setShowLogin] = useState(false);
@@ -100,8 +99,8 @@ function App() {
       </header>
       <Routes>
         <Route path="/register" element={<RegisterPage />} />
-        <Route path="/login" element={<LoginPage onLogin={setUsername} />} />
-        <Route path="/" element={<WeatherApp username={username} onLogout={handleLogout} />} />
+        <Route path="/login" element={<LoginPage onLogin={setUser} />} />
+        <Route path="/" element={<WeatherApp user={user} onLogout={handleLogout} />} />
       </Routes>
     </div>
   );

--- a/src/WeatherApp.jsx
+++ b/src/WeatherApp.jsx
@@ -4,7 +4,7 @@ import SearchBar from './components/searchbar';
 import WeatherCard from './components/WeatherCard';
 import './App.css';
 
-function WeatherApp({ username, onLogout }) {
+function WeatherApp({ user, onLogout }) {
   const navigate = useNavigate();
   const [weatherList, setWeatherList] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -121,9 +121,9 @@ function WeatherApp({ username, onLogout }) {
 
       <header className="app-header">
         <h1>Meteosphere🌤️</h1>
-        {username && (
+        {user && (
           <div className="user-info">
-            <span className="user-email">{username}</span>
+            <span className="user-email">{user.email}</span>
             <button className="logout-btn" onClick={handleLogout}>Çıkış Yap</button>
           </div>
         )}
@@ -136,7 +136,7 @@ function WeatherApp({ username, onLogout }) {
           <WeatherCard
             data={weatherList[currentIndex]}
             onDelete={handleDelete}
-            user={username ? { email: username } : null}
+            user={user}
             onLoginRequest={() => navigate('/login')}
           />
         </div>

--- a/src/components/AuthPage.jsx
+++ b/src/components/AuthPage.jsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import './auth.css';
 
-const API_URL = import.meta.env.VITE_API_URL;
-
 function AuthPage( { onLogin }){
     const [isLogin, setIsLogin] = useState(true);
     const [email, setEmail] = useState("");
@@ -14,7 +12,7 @@ function AuthPage( { onLogin }){
 
         if (email && password) {
             try {
-                const res = await fetch(`${API_URL}/login`, {
+                const res = await fetch('/api/auth/login', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ email, password })
@@ -22,7 +20,7 @@ function AuthPage( { onLogin }){
                 if (!res.ok) throw new Error('Login failed');
                 const data = await res.json();
                 localStorage.setItem('token', data.token);
-                onLogin({ email });
+                onLogin({ email, token: data.token });
             } catch {
                 alert('Giriş başarısız');
             }

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -7,12 +7,27 @@ function LoginPage({ onLogin }) {
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!username || !password) return;
-    localStorage.setItem('token', 'fake-jwt-token');
-    if (onLogin) onLogin(username);
-    navigate('/');
+
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: username, password }),
+      });
+
+      if (!res.ok) throw new Error('Login failed');
+
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      if (onLogin) onLogin({ email: username, token: data.token });
+      navigate('/');
+    } catch (err) {
+      console.error(err);
+      alert('Giriş başarısız');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- send login data from LoginPage to `/api/auth/login`
- store returned token and pass it along to CommentSection
- update AuthPage login endpoint
- track logged-in user object in `App` and `WeatherApp`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68559ad38e3c832998f36b01eb2693ae