### PR TITLE
Unify backend entry point

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:3001
+VITE_API_URL=http://localhost:5000

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "node server.js"
+    "server": "node server.js",
+    "start:server": "node server/index.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,15 +1,57 @@
 /* eslint-env node */
 import express from "express";
 import mongoose from "mongoose";
+import cors from "cors";
+import jwt from "jsonwebtoken";
+import dotenv from "dotenv";
 import commentsRouter from "./routes/comments.js";
+import authRoute from "./routes/auth.js";
+
+dotenv.config();
 
 const app = express();
 
+app.use(cors());
 app.use(express.json());
+app.use('/api/auth', authRoute);
 app.use("/api/comments", commentsRouter);
 
+// existing simple login for AuthPage popup
+app.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password required' });
+  }
+  const token = jwt.sign({ email }, process.env.JWT_SECRET || 'secret');
+  res.json({ token });
+});
+
+// mock weather endpoint
+app.get('/weather/:city', (req, res) => {
+  const { city } = req.params;
+  const data = {
+    id: city,
+    location_name: city.charAt(0).toUpperCase() + city.slice(1),
+    latitude: 0,
+    longitude: 0,
+    datetime: new Date().toISOString(),
+    temperature: 25,
+    humidity: 50,
+    weather_description: 'Açık',
+    wind_speed: 3,
+    wind_direction: 90,
+    pressure: 1010,
+    icon_code: '01d',
+    expertOpinions: [],
+  };
+  res.json(data);
+});
+
 const PORT = process.env.PORT || 5000;
-const MONGO_URI = process.env.MONGO_URI || "mongodb://localhost:27017/weather";
+const MONGO_URI =
+  process.env.MONGO_URI ||
+  process.env.MONGO_URL ||
+  "mongodb://localhost:27017/weather";
 
 mongoose
   .connect(MONGO_URI)


### PR DESCRIPTION
## Summary
- merge simple login and weather mock API into `server/index.js`
- add server script to package.json
- update `VITE_API_URL` to point to new backend

## Testing
- `npm run lint`
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68559ad3dfd483299a55b84920ac5ad2