### PR TITLE
Connect registration to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ npm run dev
 
 Projede gezinme için `react-router-dom` paketine ihtiyaç vardır. Bağımlılıkların kurulduğundan emin olmak için `npm install` komutunu çalıştırın.
 
+MongoDB kullanmak için kök dizindeki `.env` dosyasına bağlantı adresinizi
+`MONGO_URI` olarak ekleyin ve sunucuyu aşağıdaki komutla başlatın:
+
+```bash
+npm run start:server
+```
+
 Bu komutlar gerekli paketleri kurar ve geliştirme sunucusunu `http://localhost:5173` adresinde başlatır.
 
 ## Proje Yapısı

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -8,11 +8,25 @@ function RegisterPage() {
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!username || !email || !password) return;
-    alert('Kayıt başarılı!');
-    navigate('/login');
+
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password }),
+      });
+
+      if (!res.ok) throw new Error('Register failed');
+
+      alert('Kayıt başarılı!');
+      navigate('/login');
+    } catch (err) {
+      console.error(err);
+      alert('Kayıt başarısız');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- send registration data to `/api/auth/register`
- document how to configure MongoDB connection and start the backend

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68559feac2a48329ab737181778a2cbd